### PR TITLE
Travis-ci works after the Rmpi package is installed correctly.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,6 @@
 README.md
-.git
-.gitignore
-.travis.yml
+\.git
+\.gitignore
+\.travis\.yml
+\.DS_Store
+\.\.Rcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,13 @@
 
 language: r
 cache: packages
-
-warnings_are_errors: false
 sudo: required
 
-r: - release
+warnings_are_errors: false
 
 env:
   global: 
-    - _R_CHECK_FORCE_SUGGESTS_ = false
+    - CRAN: http://cran.rstudio.com
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: r
 cache: packages
+
+warnings_are_errors: false
 sudo: required
 
 r: - release

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ before_install:
   - chmod 755 ./travis-tool.sh
   - ./travis-tool.sh install_aptget r-cran-rmpi
 
-warnings_are_errors: false
-
 env:
   global: 
     - CRAN: http://cran.rstudio.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
-# Sample .travis.yml for R projects
-
 language: 
     - r
     - cpp
-    - c
 
 cache: packages
 sudo: required
@@ -17,11 +14,6 @@ before_install:
   - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
   - chmod 755 ./travis-tool.sh
   - ./travis-tool.sh install_aptget r-cran-rmpi
-
-# before_script:
-#   - sudo apt-get install libopenmpi-dev openmpi-bin libhdf5-openmpi-dev
-# install:
-#   - ./travis-tool.sh install_deps
 
 warnings_are_errors: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ compiler:
     - gcc
     - g++
 
+before_script:
+  - sudo apt-get install libopenmpi-dev openmpi-bin libhdf5-openmpi-dev
+
 warnings_are_errors: false
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 language: 
     - r
     - cpp
+    - c
 
 cache: packages
 sudo: required
@@ -12,8 +13,15 @@ compiler:
     - gcc
     - g++
 
-before_script:
-  - sudo apt-get install libopenmpi-dev openmpi-bin libhdf5-openmpi-dev
+before_install:
+  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+  - chmod 755 ./travis-tool.sh
+  - ./travis-tool.sh install_aptget r-cran-rmpi
+
+# before_script:
+#   - sudo apt-get install libopenmpi-dev openmpi-bin libhdf5-openmpi-dev
+# install:
+#   - ./travis-tool.sh install_deps
 
 warnings_are_errors: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 # Sample .travis.yml for R projects
 
-language: r
+language: 
+    - r
+    - cpp
+
 cache: packages
 sudo: required
+
+compiler:
+    - clang
+    - gcc
+    - g++
 
 warnings_are_errors: false
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,8 +6,8 @@ Author: Ben Fifield <bfifield@princeton.edu>, Alexander Tarr <atarr@princeton.ed
 Maintainer: Ben Fifield <bfifield@princeton.edu>
 Description: Enables researchers to sample redistricting plans from a pre-specified target distribution using a Markov Chain Monte Carlo algorithm. The package allows for the implementation of various constraints in the redistricting process such as geographic compactness and population parity requirements.  The algorithm also can be used in combination with efficient simulation methods such as simulated and parallel tempering algorithms. Tools for analysis such as inverse probability reweighting and plotting functionality are included. The package implements methods described in Fifield, Higgins, Imai and Tarr (2015) ``A New Automated Redistricting Simulator Using Markov Chain Monte Carlo,'' working paper available at <http://http://imai.princeton.edu/research/files/redist.pdf>.
 Depends: R (>= 3.1.0)
-Imports: Rcpp (>= 0.11.0), spdep, sp, coda, parallel, doParallel, foreach
-Suggests: testthat, Rmpi
+Imports: Rcpp (>= 0.11.0), spdep, sp, coda, parallel, doParallel, foreach, Rmpi
+Suggests: testthat
 LinkingTo: Rcpp, RcppArmadillo
 License: GPL (>= 2)
 SystemRequirements: gmp, libxml2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,8 +6,8 @@ Author: Ben Fifield <bfifield@princeton.edu>, Alexander Tarr <atarr@princeton.ed
 Maintainer: Ben Fifield <bfifield@princeton.edu>
 Description: Enables researchers to sample redistricting plans from a pre-specified target distribution using a Markov Chain Monte Carlo algorithm. The package allows for the implementation of various constraints in the redistricting process such as geographic compactness and population parity requirements.  The algorithm also can be used in combination with efficient simulation methods such as simulated and parallel tempering algorithms. Tools for analysis such as inverse probability reweighting and plotting functionality are included. The package implements methods described in Fifield, Higgins, Imai and Tarr (2015) ``A New Automated Redistricting Simulator Using Markov Chain Monte Carlo,'' working paper available at <http://http://imai.princeton.edu/research/files/redist.pdf>.
 Depends: R (>= 3.1.0)
-Imports: Rcpp (>= 0.11.0), spdep, sp, coda, parallel, doParallel, foreach, Rmpi
-Suggests: testthat
+Imports: Rcpp (>= 0.11.0), spdep, sp, coda, parallel, doParallel, foreach
+Suggests: testthat, Rmpi
 LinkingTo: Rcpp, RcppArmadillo
 License: GPL (>= 2)
 SystemRequirements: gmp, libxml2


### PR DESCRIPTION
It passed travis check (https://travis-ci.org/HJ08003/redist/builds/185528982)

The issue with previous travis-ci set up is about the Rmpi package. When it is part of the "Suggests" in DESCRIPTION, Rmpi becomes uninstalled during travis-ci check. However, if it is part of the "Imports", the default dependent package installation mechanism does not work for Rmpi.  A solution is to use travis-tool.sh to install it directly from cran by the command line.

#==================================================
before_install:
  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
  - chmod 755 ./travis-tool.sh
  - ./travis-tool.sh install_aptget r-cran-rmpi
#==================================================
