### PR TITLE
Description and Explicit Type Conversion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: redist
-Version: 2.0.1
-Date: 2020-09-09
+Version: 2.0.2
+Date: 2020-09-20
 Title: Simulation Methods for Legislative Redistricting
 Authors@R: c(
     person("Ben", "Fifield", email = "benfifield@gmail.com", role = c("aut", "cre")),

--- a/src/map_calc.cpp
+++ b/src/map_calc.cpp
@@ -22,7 +22,7 @@ double log_boundary(const Graph &g, const subview_col<uword> &districts,
         }
     }
 
-    return log(count);
+    return log((double)count);
 }
 
 

--- a/src/minkowski.cpp
+++ b/src/minkowski.cpp
@@ -1,15 +1,15 @@
-#include <RcppArmadillo.h>
+#include <Rcpp.h>
 using namespace Rcpp;
 
 // [[Rcpp::export]]
 NumericVector minkowski(IntegerVector v, IntegerMatrix m, int p) {
-  double mink = 0, diff; 
+  double mink = 0.0, diff; 
   int i = 0, c = 0;
   NumericVector result(m.ncol());
   for(c = 0; c < m.ncol(); c++){
     mink = 0;
     for(i = 0; i < v.size(); i++){
-      diff = pow(abs(v[i] - m(i, c)), p);
+      diff = pow((double)(abs(v[i] - m(i, c))), (double)p);
       mink+= diff;
     }
     mink = pow(mink, 1.0/p);

--- a/src/smc.cpp
+++ b/src/smc.cpp
@@ -38,7 +38,7 @@ IntegerMatrix smc_plans(int N, List l, const uvec &counties,
     vec lp(N_max, fill::zeros);
 
     int k;
-    int N_adapt = std::min((int) std::floor(4000.0 / sqrt(V)), N_max);
+    int N_adapt = std::min((int) std::floor(4000.0 / sqrt((double)V)), N_max);
     int N_sample = 0;
     int valid = N_adapt;
     double prob;
@@ -197,7 +197,7 @@ double split_map(const Graph &g, const uvec &counties, Multigraph &cg,
                           lower, upper, target);
     if (lower == 0) return -log(0.0); // reject sample
 
-    return log_boundary(g, districts, 0, dist_ctr) - log(k);
+    return log_boundary(g, districts, 0, dist_ctr) - log((double)k);
 }
 
 


### PR DESCRIPTION
Solaris wanted more explicit typing for log, pow, and sqrt. This increments the version number and fixes those cases.