### PR TITLE
Make input check error messages more helpful

### DIFF
--- a/R/redist-preproc.R
+++ b/R/redist-preproc.R
@@ -316,7 +316,7 @@ redist.preproc <- function(adj, total_pop, init_plan = NULL, ndists = NULL,
     init_plan <- init_plan - min(init_plan)
   }
   if(length(unique(init_plan)) != (max(init_plan) + 1)){
-    stop("init_plan must be a sequence increasing by 1")
+    stop("The district numbers in init_plan must be consecutive. For input `x`, consider transforming to `match(x, unique(x))` beforehand.")
   }
   
   ## ------------------------------------
@@ -360,6 +360,9 @@ redist.preproc <- function(adj, total_pop, init_plan = NULL, ndists = NULL,
   }else{
     if(is.factor(counties)){
       counties <- as.numeric(counties)
+    }
+    if(is.character(counties)){
+     stop("Vector of counties must be numeric or factor.")
     }
     counties <- counties - min(counties)
   }


### PR DESCRIPTION
Counties input

- unless an explicit error condition is given, users get `"non-numeric argument to binary operator"` and hard to tell why. Requirement not documented in help page either


"init_plan must be a sequence increasing by 1"

- Better to give a suggested solution. It would have taken me many minutes to figure it out had @tylersimko not given the proposal belwo beforehand
- The wording is a bit misleading because the sequence need not be ordered.


``` r
x <- c(1, 1000, 100, 100)
match(x, unique(x))
#> [1] 1 2 3 3
```

<sup>Created on 2021-03-24 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>